### PR TITLE
Coloquei no app/page um redirect pro /home

### DIFF
--- a/fronttradulibras/src/app/page.js
+++ b/fronttradulibras/src/app/page.js
@@ -1,5 +1,6 @@
-import Image from 'next/image';
+// app/page.js
+import { redirect } from 'next/navigation';
 
 export default function Home() {
-  return <div className=""></div>;
+  redirect('/home');
 }


### PR DESCRIPTION
This pull request includes a change to the `fronttradulibras/src/app/page.js` file. The change involves removing an unused import and updating the `Home` function to perform a redirect.

* Removed unused import `Image` from 'next/image'.
* Updated `Home` function to use the `redirect` method from 'next/navigation' to redirect to '/home'.