### PR TITLE
Coloque um link no botao "traduzir"do home

### DIFF
--- a/fronttradulibras/src/components/home/content.jsx
+++ b/fronttradulibras/src/components/home/content.jsx
@@ -75,13 +75,17 @@ export default function ContentHome() {
       </div>
 
       <div className="mt-10 grid grid-cols-1 md:grid-cols-3 gap-6 text-center">
-        <button className="p-6 bg-white rounded-lg shadow-md hover:shadow-lg transition transform hover:scale-105 flex flex-col items-center">
-          <BookOpen className="text-darkbluetradu w-12 h-12 mb-2" />
-          <h3 className="text-lg font-semibold text-orangetradu mt-2">Traduzir</h3>
-          <p className="text-gray-600 text-sm">
-            Converta palavras em Libras de forma rápida e intuitiva.
-          </p>
-        </button>
+      <button
+  onClick={() => router.push("/translator")}
+  className="p-6 bg-white rounded-lg shadow-md hover:shadow-lg transition transform hover:scale-105 flex flex-col items-center"
+>
+  <BookOpen className="text-darkbluetradu w-12 h-12 mb-2" />
+  <h3 className="text-lg font-semibold text-orangetradu mt-2">Traduzir</h3>
+  <p className="text-gray-600 text-sm">
+    Converta palavras em Libras de forma rápida e intuitiva.
+  </p>
+</button>
+
         <button className="p-6 bg-white rounded-lg shadow-md hover:shadow-lg transition transform hover:scale-105 flex flex-col items-center">
           <GraduationCap className="text-darkbluetradu w-12 h-12 mb-2" />
           <h3 className="text-lg font-semibold text-orangetradu mt-2">Aprender</h3>


### PR DESCRIPTION
This pull request includes a change to the `ContentHome` component in the `fronttradulibras` project. The change adds a click event handler to the "Traduzir" button, which navigates the user to the translator page.

* [`fronttradulibras/src/components/home/content.jsx`](diffhunk://#diff-bc7fb04177cd3e32cd3844e781bff615c2d8681ef98fb27bbd37dae919a4e289L78-R88): Added an `onClick` event to the "Traduzir" button to navigate to the `/translator` page.