### PR TITLE
Arrumei alguns bugs do chat/pag finalizada

### DIFF
--- a/fronttradulibras/src/components/translator/translator.jsx
+++ b/fronttradulibras/src/components/translator/translator.jsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { useState, useEffect } from "react";
-import { Moon, Sun } from "lucide-react";
+import { useState, useEffect, useRef } from "react";
+import { ArrowLeft, Moon, Sun } from "lucide-react";
 
 const WORD_TO_VIDEO = {
   "cadeira": "/videos/cadeira.mp4",
@@ -15,35 +15,44 @@ export default function Translator() {
   const [input, setInput] = useState("");
   const [isLoading, setIsLoading] = useState(false);
   const [searchHistory, setSearchHistory] = useState([]);
+  const bottomRef = useRef(null);
 
   useEffect(() => {
     const stored = localStorage.getItem("searchHistory");
     if (stored) {
       setSearchHistory(JSON.parse(stored));
     }
-  }, []);  // Esta linha já garante que o histórico é recuperado
-  
+  }, []);
+
+  useEffect(() => {
+    bottomRef.current?.scrollIntoView({ behavior: "smooth" });
+  }, [searchHistory]);
+
+  const getVideoForWord = (word) => {
+    const lower = word.toLowerCase();
+    return WORD_TO_VIDEO[lower] || WORD_TO_VIDEO["default"];
+  };
+
   const handleSearch = () => {
     if (!input.trim()) return;
-  
+
     setIsLoading(true);
-  
+
     const newEntry = {
       text: input,
       video: getVideoForWord(input),
       timestamp: new Date().toLocaleTimeString()
     };
-  
-    const updatedHistory = [newEntry, ...searchHistory]; // Previne sobrescrita do histórico
+
+    const updatedHistory = [...searchHistory, newEntry];
     setSearchHistory(updatedHistory);
     localStorage.setItem("searchHistory", JSON.stringify(updatedHistory));
-  
+
     setTimeout(() => {
       setIsLoading(false);
       setInput("");
     }, 2000);
   };
-  
 
   return (
     <div
@@ -53,42 +62,47 @@ export default function Translator() {
           : "bg-gradient-to-br from-gray-100 to-orange-100 text-gray-900"
       }`}
     >
-      {/* Header fixo */}
+      {/* Header fixo com botão e título na mesma linha */}
       <div
-        className={`sticky top-0 z-10 ${
-          isDark ? "bg-gray-800/90" : "bg-white/90"
-        } backdrop-blur-md p-4 shadow-md`}
-      >
-        <h2 className="text-xl font-semibold border-b-4 border-blue-400 w-fit mx-auto px-4 py-1 rounded-md">
-          Tradução
-        </h2>
-      </div>
+  className={`sticky top-0 z-10 flex items-center p-4 ${
+    isDark ? "bg-gray-800/90" : "bg-white/90"
+  } backdrop-blur-md shadow-md`}
+>
+  {/* Botão Voltar com ícone ao lado do texto */}
+  <button
+    onClick={() => window.history.back()}
+    className="bg-gray-300 text-gray-900 px-4 py-2 rounded-md hover:bg-gray-400 absolute left-60 flex items-center"
+  >
+    <ArrowLeft size={20} className="mr-2" /> {/* Ícone */}
+    Voltar {/* Texto */}
+  </button>
 
+  {/* Título Centralizado */}
+  <h2 className="text-xl font-semibold border-b-4 border-blue-400 w-fit mx-auto px-4 py-1 rounded-md">
+    Tradução
+  </h2>
+</div>
       {/* Conteúdo com rolagem */}
-      <div className="flex-1 overflow-y-auto px-4 py-2 space-y-4 w-full max-w-md mx-auto">
-      {searchHistory.length > 0 ? (
-  searchHistory.map((entry, index) => (
-    <div key={index} className="flex flex-col items-end space-y-1">
-      <div className="bg-white text-gray-800 text-sm px-4 py-2 rounded-xl shadow-md w-fit chat-bubble">
-        {entry.text}
-        <div className="text-xs text-gray-500 text-right mt-1">
-          {entry.timestamp}
+      <div className="flex-1 overflow-y-auto w-full">
+        <div className="px-4 py-2 space-y-4 flex flex-col items-end justify-end min-h-[calc(100vh-144px)] max-w-md mx-auto">
+          {searchHistory.map((entry, index) => (
+            <div key={index} className="flex flex-col items-end space-y-1 w-full max-w-xs">
+              <div className="bg-white text-gray-800 text-sm px-4 py-2 rounded-xl shadow-md w-fit chat-bubble">
+                {entry.text}
+                <div className="text-xs text-gray-500 text-right mt-1">
+                  {entry.timestamp}
+                </div>
+              </div>
+              <div className="rounded-lg bg-white shadow-md p-2 border w-full">
+                <video controls className="rounded-md w-full">
+                  <source src={entry.video} type="video/mp4" />
+                  Seu navegador não suporta o vídeo.
+                </video>
+              </div>
+            </div>
+          ))}
+          <div ref={bottomRef} />
         </div>
-      </div>
-      <div className="rounded-lg bg-white shadow-md p-2 border w-full">
-        <video controls className="rounded-md w-full">
-          <source src={entry.video} type="video/mp4" />
-          Seu navegador não suporta o vídeo.
-        </video>
-      </div>
-    </div>
-  ))
-) : (
-  <div className="flex justify-center items-center h-96">
-    <p className="text-gray-500">Nenhuma tradução ainda.</p>
-  </div>
-)}
-
       </div>
 
       {/* Input fixo abaixo */}
@@ -99,8 +113,10 @@ export default function Translator() {
       >
         <div className="relative flex items-center w-full max-w-md mx-auto">
           {input.length > 0 && (
-            <div className="absolute -top-12 right-0 bg-white text-gray-800 text-sm px-4 py-2 rounded-xl shadow-md max-w-xs chat-bubble animate-pulse">
-              <span className="dot-typing">...</span>
+            <div className="absolute -top-12 right-0 flex justify-end w-full">
+              <div className="bg-white text-gray-800 text-sm px-4 py-2 rounded-xl shadow-md max-w-xs chat-bubble animate-pulse">
+                <span className="dot-typing">...</span>
+              </div>
             </div>
           )}
           <input
@@ -130,7 +146,7 @@ export default function Translator() {
           content: "";
           position: absolute;
           bottom: -8px;
-          right: 12px; /* Posicionamento ajustado para a direita */
+          right: 12px;
           width: 0;
           height: 0;
           border: 8px solid transparent;
@@ -155,25 +171,11 @@ export default function Translator() {
           }
         }
 
-        /* Ajustes globais */
         html,
         body {
           height: 100%;
           margin: 0;
-          overflow: hidden; /* Evita o scroll externo */
-        }
-
-        .flex {
-          height: 100%;
-        }
-
-        .flex-1 {
-          flex: 1;
-          overflow-y: auto; /* Permite rolagem apenas dentro do conteúdo */
-        }
-
-        .overflow-y-auto {
-          overflow-y: auto;
+          overflow: hidden;
         }
       `}</style>
     </div>


### PR DESCRIPTION
This pull request introduces several updates to the `Translator` component in `translator.jsx`, focusing on improving user experience, UI functionality, and code maintainability. Key changes include the addition of a "Back" button in the header, automatic scrolling for new search history entries, and refinements to the layout and styling of the component.

### Functional Enhancements:
* Added a "Back" button with an `ArrowLeft` icon in the header to allow users to navigate back to the previous page. (`[fronttradulibras/src/components/translator/translator.jsxL56-R89](diffhunk://#diff-95a71c1586b013a897cc6defb98f440ee876065c79b46f58ae0a4bbd83806448L56-R89)`)
* Introduced a `useRef` hook (`bottomRef`) to enable automatic scrolling to the latest search history entry when the history updates. (`[[1]](diffhunk://#diff-95a71c1586b013a897cc6defb98f440ee876065c79b46f58ae0a4bbd83806448R18-R34)`, `[[2]](diffhunk://#diff-95a71c1586b013a897cc6defb98f440ee876065c79b46f58ae0a4bbd83806448L85-L91)`)

### UI Improvements:
* Updated the header layout to align the "Back" button and the title on the same line, improving visual consistency. (`[fronttradulibras/src/components/translator/translator.jsxL56-R89](diffhunk://#diff-95a71c1586b013a897cc6defb98f440ee876065c79b46f58ae0a4bbd83806448L56-R89)`)
* Adjusted the layout of the search history and input bubble for better responsiveness and alignment. (`[[1]](diffhunk://#diff-95a71c1586b013a897cc6defb98f440ee876065c79b46f58ae0a4bbd83806448L56-R89)`, `[[2]](diffhunk://#diff-95a71c1586b013a897cc6defb98f440ee876065c79b46f58ae0a4bbd83806448L102-R120)`)

### Code Refinements:
* Changed the logic for updating `searchHistory` to append new entries at the end instead of the beginning, ensuring chronological order. (`[fronttradulibras/src/components/translator/translator.jsxL37-R47](diffhunk://#diff-95a71c1586b013a897cc6defb98f440ee876065c79b46f58ae0a4bbd83806448L37-R47)`)
* Removed redundant and unused global CSS styles to simplify the codebase. (`[fronttradulibras/src/components/translator/translator.jsxL158-R178](diffhunk://#diff-95a71c1586b013a897cc6defb98f440ee876065c79b46f58ae0a4bbd83806448L158-R178)`)